### PR TITLE
Feat/api new apis for save chat histor and update session info

### DIFF
--- a/backend/src/api/routes/chat.py
+++ b/backend/src/api/routes/chat.py
@@ -275,6 +275,7 @@ async def get_chathistory(
     -H 'accept: application/json' \
     -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFub255bW91cyIsImVtYWlsIjoiYW5vbnltb3VzQGFub255LmNvbSIsImV4cCI6MTcyMTIxMjA3NCwic3ViIjoiWU9VUi1KV1QtU1VCSkVDVCJ9.WjKiLd5wLDlzV_T2UHx8i8WFwG-rXBWmCvhovb_9lC0'
     ```
+    
     **Returns**
     
     [
@@ -365,7 +366,7 @@ async def save_chats(
         }
     ]
     }'
-    '''
+    ```
     
     **Returns**
 

--- a/backend/src/models/db/chat.py
+++ b/backend/src/models/db/chat.py
@@ -32,7 +32,7 @@ class ChatHistory(Base):  # type: ignore
 
     id: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(primary_key=True, autoincrement="auto")
     session_id: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(nullable=False)
-    is_bot_msg: SQLAlchemyMapped[bool] = sqlalchemy_mapped_column(sqlalchemy.Boolean, nullable=False, default=False)
+    role: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.Enum("user", "assistant", name="role"), nullable=False, default="user")
     message: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=4096), nullable=False)
     created_at: SQLAlchemyMapped[datetime.datetime] = sqlalchemy_mapped_column(
         sqlalchemy.DateTime(timezone=True), nullable=False, server_default=sqlalchemy_functions.now()

--- a/backend/src/models/db/chat.py
+++ b/backend/src/models/db/chat.py
@@ -15,10 +15,15 @@ class Session(Base):  # type: ignore
     uuid: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=36), nullable=False, default=lambda: str(uuid.uuid4()))
     account_id: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(nullable=True)
     name: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=64), nullable=True)
+    type: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.Enum("rag", "chat", name="session_type"), nullable=False, default="chat")
     created_at: SQLAlchemyMapped[datetime.datetime] = sqlalchemy_mapped_column(
         sqlalchemy.DateTime(timezone=True), nullable=False, server_default=sqlalchemy_functions.now()
     )
-
+    updated_at: SQLAlchemyMapped[datetime.datetime] = sqlalchemy_mapped_column(
+        sqlalchemy.DateTime(timezone=True),
+        nullable=True,
+        server_onupdate=sqlalchemy.schema.FetchedValue(for_update=True),
+    )
     __mapper_args__ = {"eager_defaults": True}
 
 

--- a/backend/src/models/schemas/chat.py
+++ b/backend/src/models/schemas/chat.py
@@ -52,6 +52,18 @@ class ChatUUIDResponse(BaseSchemaModel):
     sessionUuid: str = Field(..., title="Session UUID", description="Session UUID")
 
 class SessionUpdate(BaseSchemaModel):
+    """
+    Object for the request body of update session.
+
+    Attributes:
+    -----------
+    sessionUuid: str
+        Session UUID
+    name: str
+        session name
+    type: str
+        type of session: rag or chat
+    """
     sessionUuid: str = Field(..., title="Session UUID", description="Session UUID")
     name: Optional[str] = Field(default=None, title="Name", description="Name")
     type: Optional[Literal["rag", "chat"]] = Field(default=None, title="Type", description="Type")

--- a/backend/src/models/schemas/chat.py
+++ b/backend/src/models/schemas/chat.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import Optional
-
+from typing import Literal
 from pydantic import Field
 
 from src.models.schemas.base import BaseSchemaModel
@@ -51,10 +51,16 @@ class ChatUUIDResponse(BaseSchemaModel):
 
     sessionUuid: str = Field(..., title="Session UUID", description="Session UUID")
 
+class SessionUpdate(BaseSchemaModel):
+    sessionUuid: str = Field(..., title="Session UUID", description="Session UUID")
+    name: Optional[str] = Field(default=None, title="Name", description="Name")
+    type: Optional[Literal["rag", "chat"]] = Field(default=None, title="Type", description="Type")
+
 class Session(BaseSchemaModel):
     sessionUuid: str = Field(..., title="Session UUID" ,description="Session UUID") 
     name: str | None  = Field(..., title="Name", description="Name") 
-    created_at: datetime.datetime = Field(..., title="Creation time", description="Creation time") 
+    type: str | None  = Field(..., title="Type", description="Type") 
+    created_at: datetime.datetime | None = Field(..., title="Creation time", description="Creation time") 
 
 
 class ChatHistory(BaseSchemaModel):

--- a/backend/src/models/schemas/chat.py
+++ b/backend/src/models/schemas/chat.py
@@ -75,7 +75,21 @@ class Session(BaseSchemaModel):
     created_at: datetime.datetime | None = Field(..., title="Creation time", description="Creation time") 
 
 
-class ChatHistory(BaseSchemaModel):
+class Chats(BaseSchemaModel):
+    """
+    Object for the response body of the chat history endpoint.
+
+    Attributes:
+    -----------
+    role: str
+        Role of chat user or assistant
+    message: str
+        Message
+    """
+    role: str  = Field(..., title="Role", description="Role ") 
+    message: str = Field(..., title="Message", description="Message")
+
+class SaveChatHistory(BaseSchemaModel):
     """
     Object for the response body of the chat history endpoint.
 
@@ -83,16 +97,13 @@ class ChatHistory(BaseSchemaModel):
     -----------
     sessionUuid: str
         Session UUID
-    chat_type: str
-        Type of chat
+    role: str
+        Role of chat user or assistant
     message: str
         Message
     """
-
-    sessionUuid: str = Field(..., title="Session UUID", description="Session UUID") 
-    chat_type: str  = Field(..., title="Chat Type", description="Type of chat") 
-    message: str = Field(..., title="Message", description="Message")
-
+    sessionUuid: str = Field(..., title="Session UUID" ,description="Session UUID")
+    chats: list[Chats] = Field(..., title="Chat history" ,description="Chat history")
 
 class MessagesResponse(BaseSchemaModel):
     role: str = Field(..., title="Role", description="Role")

--- a/backend/src/repository/crud/chat.py
+++ b/backend/src/repository/crud/chat.py
@@ -4,6 +4,7 @@ from typing import Optional
 import sqlalchemy
 
 from src.models.db.chat import ChatHistory, Session
+from src.models.schemas.chat import SessionUpdate
 from src.repository.crud.base import BaseCRUDRepository
 from src.utilities.exceptions.database import EntityDoesNotExist
 
@@ -31,6 +32,24 @@ class SessionCRUDRepository(BaseCRUDRepository):
             raise EntityDoesNotExist("Session with uuid `{session_uuid}` does not exist!")
 
         return session  # type: ignore
+
+    async def update_sessions_by_uuid(self, session: SessionUpdate, account_id: int) -> Session:
+        stmt = sqlalchemy.select(Session).where(Session.uuid == session.sessionUuid, Session.account_id == account_id)
+        query = await self.async_session.execute(statement=stmt)
+        update_session = query.scalar()
+        if update_session is None:
+            raise EntityDoesNotExist(f"Session with uuid `{session.sessionUuid}` does not exist!")
+        update_stmt = sqlalchemy.update(table=Session).where(Session.uuid == session.sessionUuid).values(updated_at=sqlalchemy_functions.now())  # type: ignore
+        if session["name"]:
+            update_stmt = update_stmt.values(username=session["name"])
+
+        if session["type"]:
+            update_stmt = update_stmt.values(type=session["type"])
+        await self.async_session.execute(statement=update_stmt)
+        await self.async_session.commit()
+        await self.async_session.refresh(instance=update_session)
+
+        return update_session  # type: ignore
 
     async def read_create_sessions_by_uuid(self, session_uuid: str, account_id: int, name: str) -> Session:
         stmt = sqlalchemy.select(Session).where(Session.uuid == session_uuid)

--- a/backend/src/repository/crud/chat.py
+++ b/backend/src/repository/crud/chat.py
@@ -2,7 +2,7 @@ import typing
 from typing import Optional
 
 import sqlalchemy
-
+from sqlalchemy.sql import functions as sqlalchemy_functions
 from src.models.db.chat import ChatHistory, Session
 from src.models.schemas.chat import SessionUpdate
 from src.repository.crud.base import BaseCRUDRepository
@@ -40,11 +40,11 @@ class SessionCRUDRepository(BaseCRUDRepository):
         if update_session is None:
             raise EntityDoesNotExist(f"Session with uuid `{session.sessionUuid}` does not exist!")
         update_stmt = sqlalchemy.update(table=Session).where(Session.uuid == session.sessionUuid).values(updated_at=sqlalchemy_functions.now())  # type: ignore
-        if session["name"]:
-            update_stmt = update_stmt.values(username=session["name"])
+        if session.name:
+            update_stmt = update_stmt.values(name=session.name)
 
-        if session["type"]:
-            update_stmt = update_stmt.values(type=session["type"])
+        if session.type:
+            update_stmt = update_stmt.values(type=session.type)
         await self.async_session.execute(statement=update_stmt)
         await self.async_session.commit()
         await self.async_session.refresh(instance=update_session)

--- a/backend/src/utilities/exceptions/http/exc_404.py
+++ b/backend/src/utilities/exceptions/http/exc_404.py
@@ -7,7 +7,8 @@ import fastapi
 from src.utilities.messages.exceptions.http.exc_details import (
     http_404_email_details,
     http_404_id_details,
-    http_404_username_details
+    http_404_username_details,
+    http_404_uuid_details,
 )
 
 
@@ -30,3 +31,10 @@ async def http_404_exc_username_not_found_request(username: str) -> Exception:
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         detail=http_404_username_details(username=username),
     )
+
+async def http_404_exc_uuid_not_found_request(uuid: str) -> Exception:
+    return fastapi.HTTPException(
+        status_code=fastapi.status.HTTP_404_NOT_FOUND,
+        detail=http_404_uuid_details(uuid=uuid),
+    )
+

--- a/backend/src/utilities/messages/exceptions/http/exc_details.py
+++ b/backend/src/utilities/messages/exceptions/http/exc_details.py
@@ -21,6 +21,8 @@ def http_401_unauthorized_details() -> str:
 def http_403_forbidden_details() -> str:
     return "Refused access to the requested resource!"
 
+def http_404_uuid_details(uuid: str) -> str:
+    return f"Either the session with uuid `{uuid}` doesn't exist, has been deleted, or you are not authorized!"
 
 def http_404_id_details(id: int) -> str:
     return f"Either the account with id `{id}` doesn't exist, has been deleted, or you are not authorized!"


### PR DESCRIPTION
**Description**

This PR  fixs #239

add POST /api/chat/save for save chat history  and PATCH  /api/chat/session for session info update

![image](https://github.com/SkywardAI/kirin/assets/22625588/4eee6ba1-f24f-490f-9d26-17c6a350049e)

![image](https://github.com/SkywardAI/kirin/assets/22625588/5f97527a-1991-444a-910f-b31c734ae854)

Also update GET /api/chat/{uuid},  now the get chat history works as expected. 

**Notes for Reviewers**


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
