### PR TITLE
remove check n_keep at the initial stage

### DIFF
--- a/backend/src/repository/events.py
+++ b/backend/src/repository/events.py
@@ -117,7 +117,8 @@ async def dispose_db_connection(backend_app: fastapi.FastAPI) -> None:
 
 async def initialize_inference_client() -> None:
     """
-    Initialize the Inference client(currently we use llamacapp)
+    Initialize the inference helper, which include the OpenAI client 
+    and the URL for the inference engine.
 
     Args:
       * backend_app (fastapi.FastAPI): The FastAPI application instance
@@ -125,9 +126,6 @@ async def initialize_inference_client() -> None:
     Returns:
         None
     """
-    loguru.logger.info("Inference Client --- Waiting for Initialization . . .")
-
-    #TODO Initialize the Inference client
+    loguru.logger.info("Inference helper --- Waiting for Initialization . . .")
     inference_helper.init()
-
-    loguru.logger.info("Inference Client --- Successfully Initialized!")
+    loguru.logger.info("Inference helper --- Successfully Initialized!")

--- a/backend/src/repository/inference_eng.py
+++ b/backend/src/repository/inference_eng.py
@@ -15,7 +15,6 @@
 
 # https://pypi.org/project/openai/1.35.5/
 import openai
-import httpx
 
 from src.config.manager import settings
 
@@ -28,7 +27,6 @@ class InferenceHelper:
         self.client=self.openai_client() # OpenAI-compatible Chat Completions API
         self.completion_url=self.instruct_infer_url()
         self.tokenization_url=self.instruct_tokenize_url()
-        self.n_keep=self.get_n_keep()
 
     
     def openai_client(self) -> openai.OpenAI:
@@ -42,25 +40,7 @@ class InferenceHelper:
         url=f'http://{self.infer_eng_url}:{self.infer_eng_port}/v1'
         api_key='sk-no-key-required'
         return openai.OpenAI(base_url=url, api_key=api_key)
-    
 
-    def get_n_keep(self) -> int:
-        """
-        We get n_keep dynamically for the instruction.
-
-        Returns:
-        int: n_keep
-        """
-        with httpx.Client() as client:
-            res=client.post(
-                self.tokenization_url, 
-                headers={'Content-Type': 'application/json'}, 
-                json={"content": self.instruction}
-            )
-            res.raise_for_status()
-            tokenized_instruction = res.json().get('tokens')
-            n_keep=len(tokenized_instruction)
-        return n_keep
 
     def instruct_tokenize_url(self)->str:
         """

--- a/backend/src/repository/rag/chat.py
+++ b/backend/src/repository/rag/chat.py
@@ -241,7 +241,7 @@ class RAGChatModelRepository(BaseRAGRepository):
             "temperature": temperature,
             "top_k": top_k,
             "top_p": top_p,
-            "n_keep": inference_helper.n_keep,
+            "n_keep": 0, # If the context window is full, we keep 0 tokens
             "n_predict": n_predict,
             "cache_prompt": "false",
             "slot_id": -1, # for cached prompt

--- a/backend/src/utilities/httpkit/method_kit.py
+++ b/backend/src/utilities/httpkit/method_kit.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import httpx
+
+class MethodKit:
+    """
+    A class that contains http methods for the HTTPKit class.
+    """
+
+    def __init__(self):
+        raise EnvironmentError(
+            "This MethodKit is not meant to be instantiated. Use the methods directly."
+        )
+
+    @classmethod
+    def http_post(cls, *args, **kwargs)-> httpx.Response:
+        """
+        Post request with httpx client.
+
+        Args:
+        *args: Variable length argument list.
+        **kwargs: Arbitrary keyword arguments.
+            * url: URL to post to.
+            * json: JSON data to post.
+            * headers: Headers to send.
+            * timeout: Timeout for the request.
+
+        Returns:
+        httpx.Response: Response from the server.
+        """
+        url = kwargs.get("url")
+        jason_content = kwargs.get("json")
+        headers = kwargs.get("headers")
+        timeout = kwargs.get("timeout")
+
+        with httpx.Client() as client:
+            res = client.post(
+                url,
+                headers=headers,
+                json=jason_content,
+                timeout=timeout
+            )
+
+            res.raise_for_status()
+            return res

--- a/backend/tests/unit_tests/test_method_kit.py
+++ b/backend/tests/unit_tests/test_method_kit.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.utillities httpkit import MethodKit
+
+
+def test_http_post()-> None:
+    """
+    Test the http_post method.
+
+    In this test case we calculate the the length of tokens of the content "Hello, World!".
+
+    """
+    url = "http://llamacpp:8080/tokenize"
+    jason_content = {"content": "Hello, World!"}
+    headers={'Content-Type': 'application/json'}
+    timeout = 10
+
+    res = MethodKit.http_post(
+        url=url,
+        jason_content=jason_content,
+        headers=headers,
+        timeout=timeout
+    )
+
+    assert res.status_code == 200
+    # length of token is a integer
+    assert isinstance(res.json().get('tokens'), int)


### PR DESCRIPTION
**Description**

This PR fixes #245 

**Notes for Reviewers**

I was misunderstanding of how to using `n_keep`. We want to get `n_keep` at the initial stage is incorrect. We should get it for the latest response of the model. So, it should be dynamic. 

However, I'm not sure it will cause the any performance issue of chat feature. So, we set it to 0. If the number of token exceed the context size, we keep 0 of previous tokens.


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
