### PR TITLE
Add unittest in makefile, CI and  replace attributes of API aggregator

### DIFF
--- a/.github/workflows/linter-and-builder.yaml
+++ b/.github/workflows/linter-and-builder.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Check repository
         uses: actions/checkout@v4
 
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -42,10 +41,54 @@ jobs:
       - name: Lint with ruff
         run: |
           make ruff
+  
+  unittest:
+    name: 'Unit Test 🧪'
+    needs: [code-quality]
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.11"
+        poetry-version:
+          - "1.8.2"
+        pytest-version:
+          - "8.1.1"
+    # No need to set to specific directory
+    # defaults:
+    #   run:
+    #     working-directory: backend/
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Check repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+
+      - name: Install Dependencies for Unit Test
+        run: |
+          pip install -r backend/requirements.txt
+      
+      - name: Install PyTest
+        run: |
+          pip install pytest==${{ matrix.pytest-version }}
+
+      - name: Run Unit Test
+        run: |
+          make env
+          make test
 
   check-build-images:
     name: 'Docker Build Checker🐳'
-    needs: [code-quality]
+    needs: [code-quality, unittest]
     strategy:
       matrix:
         config:

--- a/Makefile
+++ b/Makefile
@@ -230,13 +230,8 @@ expo:
 	@poetry -C backend export -f requirements.txt --output backend/requirements.txt
 
 ############################################################################################################
-# Linter and test
-
-.PHONY: lint
-lint:
-	@ruff check --output-format=github .
-
+# Testing
 
 .PHONY: test
 test:
-	@poetry run -C backend python -m unittest discover -s backend/tests/ -v
+	@pytest backend/tests

--- a/backend/src/api/routes/version.py
+++ b/backend/src/api/routes/version.py
@@ -41,7 +41,7 @@ async def get_version() -> ServiceVersionResponse:
     """
 
     return ServiceVersionResponse(
-        kirin=settings.VERSION,
+        kirin=settings.BACKEND_SERVER_VERSION,
         milvus=settings.MILVUS_VERSION,
         llamacpp=settings.INFERENCE_ENG_VERSION
   )

--- a/backend/src/config/settings/base.py
+++ b/backend/src/config/settings/base.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import pathlib
 
@@ -10,14 +25,14 @@ ROOT_DIR: pathlib.Path = pathlib.Path(__file__).parent.parent.parent.parent.pare
 
 class BackendBaseSettings(BaseSettings):
     TITLE: str = "Kirin Aggregator"
-    VERSION: str = decouple.config("BACKEND_SERVER_VERSION", cast=str)
+    BACKEND_SERVER_VERSION: str = decouple.config("BACKEND_SERVER_VERSION", cast=str)
     TIMEZONE: str = decouple.config("TIMEZONE", cast=str)
     DESCRIPTION: str | None = None
     DEBUG: bool = False
 
-    SERVER_HOST: str = decouple.config("BACKEND_SERVER_HOST", cast=str)  # type: ignore
-    SERVER_PORT: int = decouple.config("BACKEND_SERVER_PORT", cast=int)  # type: ignore
-    SERVER_WORKERS: int = decouple.config("BACKEND_SERVER_WORKERS", cast=int)  # type: ignore
+    BACKEND_SERVER_HOST: str = decouple.config("BACKEND_SERVER_HOST", cast=str)  # type: ignore
+    BACKEND_SERVER_PORT: int = decouple.config("BACKEND_SERVER_PORT", cast=int)  # type: ignore
+    BACKEND_SERVER_WORKERS: int = decouple.config("BACKEND_SERVER_WORKERS", cast=int)  # type: ignore
     API_PREFIX: str = "/api"
     DOCS_URL: str = "/docs"
     OPENAPI_URL: str = "/openapi.json"
@@ -27,16 +42,22 @@ class BackendBaseSettings(BaseSettings):
     MILVUS_HOST: str = decouple.config("MILVUS_HOST", cast=str)  # type: ignore
     MILVUS_PORT: int = decouple.config("MILVUS_PORT", cast=int)  # type: ignore
     MILVUS_VERSION: str = decouple.config("MILVUS_VERSION", cast=str)  # type: ignore
-    DB_POSTGRES_HOST: str = decouple.config("POSTGRES_HOST", cast=str)  # type: ignore
+    ETCD_AUTO_COMPACTION_MODE: str = decouple.config("ETCD_AUTO_COMPACTION_MODE", cast=str)  # type: ignore
+    ETCD_AUTO_COMPACTION_RETENTION: str = decouple.config("ETCD_AUTO_COMPACTION_RETENTION", cast=str)  # type: ignore
+    ETCD_QUOTA_BACKEND_BYTES : str = decouple.config("ETCD_QUOTA_BACKEND_BYTES", cast=str)  # type: ignore
+
+
+    POSTGRES_HOST: str = decouple.config("POSTGRES_HOST", cast=str)  # type: ignore
     DB_MAX_POOL_CON: int = decouple.config("DB_MAX_POOL_CON", cast=int)  # type: ignore
-    DB_POSTGRES_NAME: str = decouple.config("POSTGRES_DB", cast=str)  # type: ignore
-    DB_POSTGRES_PASSWORD: str = decouple.config("POSTGRES_PASSWORD", cast=str)  # type: ignore
+    POSTGRES_DB: str = decouple.config("POSTGRES_DB", cast=str)  # type: ignore
+    POSTGRES_PASSWORD: str = decouple.config("POSTGRES_PASSWORD", cast=str)  # type: ignore
     DB_POOL_SIZE: int = decouple.config("DB_POOL_SIZE", cast=int)  # type: ignore
     DB_POOL_OVERFLOW: int = decouple.config("DB_POOL_OVERFLOW", cast=int)  # type: ignore
-    DB_POSTGRES_PORT: int = decouple.config("POSTGRES_PORT", cast=int)  # type: ignore
-    DB_POSTGRES_SCHEMA: str = decouple.config("POSTGRES_SCHEMA", cast=str)  # type: ignore
+    POSTGRES_PORT: int = decouple.config("POSTGRES_PORT", cast=int)  # type: ignore
+    POSTGRES_SCHEMA: str = decouple.config("POSTGRES_SCHEMA", cast=str)  # type: ignore
     DB_TIMEOUT: int = decouple.config("DB_TIMEOUT", cast=int)  # type: ignore
-    DB_POSTGRES_USERNAME: str = decouple.config("POSTGRES_USERNAME", cast=str)  # type: ignore
+    POSTGRES_USERNAME: str = decouple.config("POSTGRES_USERNAME", cast=str)  # type: ignore
+    POSTGRES_URI: str = decouple.config("POSTGRES_URI", cast=str)  # type: ignore
 
     IS_DB_ECHO_LOG: bool = decouple.config("IS_DB_ECHO_LOG", cast=bool)  # type: ignore
     IS_DB_FORCE_ROLLBACK: bool = decouple.config("IS_DB_FORCE_ROLLBACK", cast=bool)  # type: ignore
@@ -77,6 +98,7 @@ class BackendBaseSettings(BaseSettings):
     INFERENCE_ENG: str = decouple.config("INFERENCE_ENG", cast=str) # type: ignore
     INFERENCE_ENG_PORT: int=decouple.config("INFERENCE_ENG_PORT", cast=int) # type: ignore
     INFERENCE_ENG_VERSION: str = decouple.config("INFERENCE_ENG_VERSION", cast=str) # type: ignore
+    NUM_CPU_CORES : float = decouple.config("NUM_CPU_CORES", cast=float)  # type: ignore
     
     # Configurations for language model
     LANGUAGE_MODEL_NAME: str = decouple.config("LANGUAGE_MODEL_NAME", cast=str) # type: ignore
@@ -96,7 +118,7 @@ class BackendBaseSettings(BaseSettings):
         validate_assignment: bool = True
         # https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra
         #TODO: We need to make sure pydanic is really useful
-        extra='allow'
+        # extra='allow'
 
     @property
     def set_backend_app_attributes(self) -> dict[str, str | bool | None]:
@@ -105,7 +127,7 @@ class BackendBaseSettings(BaseSettings):
         """
         return {
             "title": self.TITLE,
-            "version": self.VERSION,
+            "version": self.BACKEND_SERVER_VERSION,
             "debug": self.DEBUG,
             "description": self.DESCRIPTION,
             "docs_url": self.DOCS_URL,

--- a/backend/src/config/settings/development.py
+++ b/backend/src/config/settings/development.py
@@ -1,3 +1,19 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from src.config.settings.base import BackendBaseSettings
 from src.config.settings.environment import Environment
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -40,9 +40,9 @@ backend_app: fastapi.FastAPI = initialize_backend_application()
 if __name__ == "__main__":
     uvicorn.run(
         app="main:backend_app",
-        host=settings.SERVER_HOST,
-        port=settings.SERVER_PORT,
+        host=settings.BACKEND_SERVER_HOST,
+        port=settings.BACKEND_SERVER_PORT,
         reload=settings.DEBUG,
-        workers=settings.SERVER_WORKERS,
+        workers=settings.BACKEND_SERVER_WORKERS,
         log_level=settings.LOGGING_LEVEL,
     )

--- a/backend/src/repository/database.py
+++ b/backend/src/repository/database.py
@@ -12,18 +12,18 @@ from src.config.manager import settings
 class AsyncDatabase:
     def __init__(self):
         self.postgres_uri: pydantic.PostgresDsn = pydantic.PostgresDsn(
-            url=f"{settings.DB_POSTGRES_SCHEMA}://{settings.DB_POSTGRES_USERNAME}:{settings.DB_POSTGRES_PASSWORD}@{settings.DB_POSTGRES_HOST}:{settings.DB_POSTGRES_PORT}/{settings.DB_POSTGRES_NAME}",
-            # scheme=settings.DB_POSTGRES_SCHEMA,
+            url=f"{settings.POSTGRES_SCHEMA}://{settings.POSTGRES_USERNAME}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}",
+            # scheme=settings.POSTGRES_SCHEMA,
         )
         self.async_engine: SQLAlchemyAsyncEngine = create_sqlalchemy_async_engine(
-            f"{settings.DB_POSTGRES_SCHEMA}+asyncpg://{settings.DB_POSTGRES_USERNAME}:{settings.DB_POSTGRES_PASSWORD}@{settings.DB_POSTGRES_HOST}:{settings.DB_POSTGRES_PORT}/{settings.DB_POSTGRES_NAME}"
+            f"{settings.POSTGRES_SCHEMA}+asyncpg://{settings.POSTGRES_USERNAME}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}"
             # url=self.set_async_db_uri,
             # echo=settings.IS_DB_ECHO_LOG,
             # pool_size=settings.DB_POOL_SIZE,
             # max_overflow=settings.DB_POOL_OVERFLOW,
             # poolclass=SQLAlchemyQueuePool,
         )
-        self.sync_engine =create_engine(f"{settings.DB_POSTGRES_SCHEMA}://{settings.DB_POSTGRES_USERNAME}:{settings.DB_POSTGRES_PASSWORD}@{settings.DB_POSTGRES_HOST}:{settings.DB_POSTGRES_PORT}/{settings.DB_POSTGRES_NAME}")
+        self.sync_engine =create_engine(f"{settings.POSTGRES_SCHEMA}://{settings.POSTGRES_USERNAME}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}")
         self.async_session: SQLAlchemyAsyncSession = SQLAlchemyAsyncSession(bind=self.async_engine)
         self.pool: SQLAlchemyPool = self.async_engine.pool
 

--- a/backend/src/repository/inference_eng.py
+++ b/backend/src/repository/inference_eng.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+
 # Copyright [2024] [SkywardAI]
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/backend/src/repository/rag/chat.py
+++ b/backend/src/repository/rag/chat.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import csv
 import loguru
 import httpx

--- a/backend/tests/unit_tests/test_method_kit.py
+++ b/backend/tests/unit_tests/test_method_kit.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import unittest
-from backend.src.utilities.httpkit.method_kit import MethodKit
+from src.utilities.httpkit.method_kit import MethodKit
 
 @unittest.skip("Skip due to the fact that the server is not running")
 class TestHTTPKits(unittest.TestCase):

--- a/backend/tests/unit_tests/test_src.py
+++ b/backend/tests/unit_tests/test_src.py
@@ -1,16 +1,37 @@
+# coding=utf-8
+
+# Copyright [2024] [SkywardAI]
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# import unittest
 # import fastapi
 
-# import src
 # from src.main import backend_app
 
+# @unittest.skip("We ned to mock this test")
+# class TestBasicFunctionality(unittest.TestCase):
+#     @classmethod
+#     def setUpClass(cls) -> None:
+#         return super().setUpClass()
 
-# def test_src_version() -> None:
-#     assert src.__version__ == "0.0.1"
+#     @classmethod
+#     def tearDownClass(cls) -> None:
+#         return super().tearDownClass()
 
 
-# def test_application_is_fastapi_instance() -> None:
-#     assert isinstance(backend_app, fastapi.FastAPI)
-#     assert backend_app.redoc_url == "/redoc"
-#     assert backend_app.docs_url == "/docs"
-#     assert backend_app.openapi_url == "/openapi.json"
-#     assert backend_app.redoc_url == "/redoc"
+#     def test_application_is_fastapi_instance(self) -> None:
+#         assert isinstance(backend_app, fastapi.FastAPI)
+#         assert backend_app.redoc_url == "/redoc"
+#         assert backend_app.docs_url == "/docs"
+#         assert backend_app.openapi_url == "/openapi.json"


### PR DESCRIPTION
**Description**

This PR add:

- [x] Basic test framework `pytest` and Makefile to run pytest `make test`. However, we still need to mock dependencies of APIs. So, currently `make test` isn't really useful.
- [x] Replace the attributes to environment name otherwise `pydantic` will not allow extra filed.
- [x] remove duplicate linter
- [x] Re-write the test cases

**Notes for Reviewers**

```
INFO:     Application startup complete.
INFO:     127.0.0.1:42492 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:35774 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:51636 - "GET /api/health HTTP/1.1" 200 OK
WARNING:  StatReload detected changes in 'tests/unit_tests/test_src.py'. Reloading...
INFO:     Shutting down
INFO:     Waiting for application shutdown.
2024-07-14 13:26:10.676 | INFO     | src.repository.events:dispose_db_connection:111 - Database Connection --- Disposing . . .
2024-07-14 13:26:10.676 | INFO     | src.repository.events:inspect_db_server_on_close:30 - Closing DB API Connection ---
 <AdaptedConnection <asyncpg.connection.Connection object at 0x76e179627970>>
2024-07-14 13:26:10.676 | INFO     | src.repository.events:inspect_db_server_on_close:31 - Closed Connection Record ---
 <sqlalchemy.pool.base._ConnectionRecord object at 0x76e1795bc130>
2024-07-14 13:26:10.679 | INFO     | src.repository.events:dispose_db_connection:115 - Database Connection --- Successfully Disposed!
INFO:     Application shutdown complete.
INFO:     Finished server process [106768]
2024-07-14 13:26:18.293 | INFO     | src.repository.vector_database:__init__:15 - Vector Database --- Connected to Milvus.
INFO:     Started server process [109086]
INFO:     Waiting for application startup.
2024-07-14 13:26:18.462 | INFO     | src.repository.events:initialize_db_connection:79 - Database Connection --- Establishing . . .
2024-07-14 13:26:18.519 | INFO     | src.repository.events:inspect_db_server_on_connection:22 - New DB API Connection ---
 <AdaptedConnection <asyncpg.connection.Connection object at 0x7d768c297970>>
2024-07-14 13:26:18.520 | INFO     | src.repository.events:inspect_db_server_on_connection:23 - Connection Record ---
 <sqlalchemy.pool.base._ConnectionRecord object at 0x7d768c24c050>
2024-07-14 13:26:18.521 | INFO     | src.repository.events:initialize_db_tables:35 - Database Table Creation --- Initializing . . .
2024-07-14 13:26:18.603 | INFO     | src.repository.events:initialize_db_tables:40 - Database Table Creation --- Successfully Initialized!
2024-07-14 13:26:18.608 | INFO     | src.repository.events:initialize_anonymous_user:43 - Anonymous user --- Creating . . .
2024-07-14 13:26:18.953 | INFO     | src.repository.events:initialize_anonymous_user:58 - Anonymous user --- Successfully Created!
2024-07-14 13:26:18.954 | INFO     | src.repository.events:initialize_admin_user:61 - Admin user --- Creating . . .
2024-07-14 13:26:19.254 | INFO     | src.repository.events:initialize_admin_user:76 - Admin user --- Successfully Created!
2024-07-14 13:26:19.255 | INFO     | src.repository.events:initialize_db_connection:89 - Database Connection --- Successfully Established!
2024-07-14 13:26:19.256 | INFO     | src.repository.events:initialize_vectordb_collection:94 - Vector Database Connection --- Establishing . . .
2024-07-14 13:26:19.258 | INFO     | src.repository.vector_database:create_collection:43 - Vector Databse --- Milvus: collection default_collection exist, dropping..
2024-07-14 13:26:21.797 | INFO     | src.repository.vector_database:create_collection:47 - Vector Database --- Milvus: collection default_collection created
2024-07-14 13:26:21.797 | INFO     | src.repository.events:initialize_vectordb_collection:107 - Vector Database Connection --- Successfully Established!
2024-07-14 13:26:21.797 | INFO     | src.repository.events:initialize_inference_client:129 - Inference helper --- Waiting for Initialization . . .
2024-07-14 13:26:21.823 | INFO     | src.repository.events:initialize_inference_client:131 - Inference helper --- Successfully Initialized!
INFO:     Application startup complete.
INFO:     127.0.0.1:49358 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:55382 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:41092 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:37550 - "GET /api/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:55270 - "GET /api/health HTTP/1.1" 200 OK
```


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
